### PR TITLE
fix:NameError - undefined local variable or method `current_page'

### DIFF
--- a/app/views/resque_web/plugins/resque_scheduler/delayed/_next_more.erb
+++ b/app/views/resque_web/plugins/resque_scheduler/delayed/_next_more.erb
@@ -4,7 +4,7 @@
 <% if start - per_page >= 0 || start + per_page <= size %>
   <p class='pagination'>
     <% if start + per_page <= size %>
-      <a href="<%= current_page %>?start=<%= start + per_page %>" class='more'>&laquo;
+      <a href="<%= request.path %>?start=<%= start + per_page %>" class='more'>&laquo;
         Next</a>
     <% end %>
 
@@ -12,12 +12,12 @@
       <% if start == page_num * per_page %>
         <%= page_num %>
       <% else %>
-        <a href="<%= current_page %>?start=<%= page_num * per_page %>"> <%= page_num %></a>
+        <a href="<%= request.path %>?start=<%= page_num * per_page %>"> <%= page_num %></a>
       <% end %>
     <% end %>
 
     <% if start - per_page >= 0 %>
-      <a href="<%= current_page %>?start=<%= start - per_page %>" class='less'>Previous &raquo;</a>
+      <a href="<%= request.path %>?start=<%= start - per_page %>" class='less'>Previous &raquo;</a>
     <% end %>
   </p>
 <% end %>


### PR DESCRIPTION
When pagination is required to display the delayed jobs, an error occurs when attempting to render `_next_more.erb` as the `current_page` variable is not defined.

```
NameError - undefined local variable or method `current_page'
```

Replacing `current_page` with `request.path`

Tested with:
  resque (1.25.2)
  resque-scheduler (4.0.0)
  resque-web (0.0.6)