### PR TITLE
Fix schedule config read operation

### DIFF
--- a/app/controllers/resque_web/plugins/resque_scheduler/schedules_controller.rb
+++ b/app/controllers/resque_web/plugins/resque_scheduler/schedules_controller.rb
@@ -24,7 +24,7 @@ module ResqueWeb
         # POST /schedule/requeue
         def requeue
           @job_name = params[:job_name]
-          config = Resque.schedule[@job_name]
+          config = Resque.schedule[@job_name] || Resque.schedule[@job_name.to_sym] 
           @parameters = config['parameters'] || config[:parameters]
           if @parameters
             render 'requeue-params'


### PR DESCRIPTION
Resque schedule will use symbol most likely. We need the code to be able to read in both cases (string and symbols)