### PR TITLE
Prevent crash when current_page is nil

### DIFF
--- a/app/views/resque_web/plugins/resque_scheduler/delayed/_next_more.erb
+++ b/app/views/resque_web/plugins/resque_scheduler/delayed/_next_more.erb
@@ -1,6 +1,8 @@
 <% # per_page was added in 1.23.1; gems which add to resque-server don't pass that variable along so it would crash  %>
 <% # without a default value  %>
 <% per_page ||= 20 %>
+<% # if current_page isn't set we'll just infer it %>
+<% current_page ||= request.path %>
 <% if start - per_page >= 0 || start + per_page <= size %>
   <p class='pagination'>
     <% if start + per_page <= size %>


### PR DESCRIPTION
Currently this gem crashes when used as a Rails engine within another Rails app. The problem occurs within the pagination as the `current_page` variable isn't set. The full crash is:

```
NameError - undefined local variable or method `current_page' for #<#<Class:0x000000098b56d8>:0x00000009abdc50>:
  resque-scheduler-web (0.0.1) app/views/resque_web/plugins/resque_scheduler/delayed/_next_more.erb:7
```

To prevent this, I've altered the pagination partial to infer the current path from `request.path` if it isn't already set.
